### PR TITLE
Version update missing in POMs for web and core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,7 +26,7 @@
     <parent>
       <groupId>com.polopoly.management</groupId>
       <artifactId>rest4jmx</artifactId>
-      <version>0.2</version>
+      <version>0.3</version>
       <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,7 +55,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-	<version>4.5</version>
+        <version>4.5</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -67,6 +67,7 @@
         <groupId>javax.servlet</groupId>
         <artifactId>servlet-api</artifactId>
         <version>2.5</version>
+        <scope>provided</scope>
       </dependency>
     </dependencies>
     <build>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -27,7 +27,7 @@
       <groupId>com.polopoly.management</groupId>
       <artifactId>rest4jmx</artifactId>
       <relativePath>../pom.xml</relativePath>
-      <version>0.2</version>
+      <version>0.3</version>
     </parent>
     <dependencies>
       <dependency>


### PR DESCRIPTION
The version for the reference to the parent POM must be updated in the web and core subprojects to 0.3 as well. 
